### PR TITLE
prevent builders from being flashed

### DIFF
--- a/lua/autorun/client/cw_flashbang_restrictions.lua
+++ b/lua/autorun/client/cw_flashbang_restrictions.lua
@@ -1,0 +1,33 @@
+local PLAYER = FindMetaTable("Player")
+
+local function wrapCwFlashbang() 
+    local flash = PLAYER.cwFlashbang
+    PLAYER.cwFlashbang = function(self, intensity, duration) 
+        local inPvp = ply:GetNWBool("CFC_PvP_Mode", false)
+        if !inPvp then return end
+        
+        return flash(self, intensity, duration)
+    end
+end
+
+local function waitingFor() 
+    return PLAYER.cwFlashbang ~= nil
+end
+
+local function onTimout() 
+    print("flashbang wrapper timed out")
+end
+
+
+if Waiter then
+    Waiter.waitFor(waitingFor, wrapCwFlashbang, onTimout )
+else
+    WaiterQueue = WaiterQueue or {}
+
+    local struct = {}
+    struct["waitingFor"] = waitingFor
+    struct["onSuccess"] =  wrapCwFlashbang
+    struct["onTimeout"] = onTimout
+
+    table.insert( WaiterQueue, struct )
+end


### PR DESCRIPTION
relies on [cfc_waiter](https://github.com/CFC-Servers/cfc_waiter/)