### PR TITLE
Improved method of giving CW ammo on spawn

### DIFF
--- a/lua/autorun/server/sv_increase_starting_ammo.lua
+++ b/lua/autorun/server/sv_increase_starting_ammo.lua
@@ -6,12 +6,17 @@ local blacklistedAmmo = {
     -- we don't actually have to add RPG ammo here
 }
 
+local cwAmmo = {}
+
 function givePlayerCWAmmo( ply )
-    for ammoName, bulletInfo in pairs( CustomizableWeaponry.ammoTypes ) do
-        if not blacklistedAmmo[ammoName] then
-            ply:SetAmmo( 1000, ammoName )
-        end
+    for ammoName in pairs( cwAmmo ) do
+        ply:SetAmmo( 1000, ammoName )
     end
 end
 
 hook.Add( "PlayerSpawn", "CFC_CWEnhancements_GiveCW2Ammo", givePlayerCWAmmo )
+hook.Add( "Initialize", "CFC_CW2_GetAmmoTypes", function()
+    for ammoName in pairs( CustomizableWeaponry.ammoTypes ) do
+        cwAmmo[ammoName] = blacklistedAmmo[ammoName] == nil
+    end
+end )

--- a/lua/autorun/server/sv_increase_starting_ammo.lua
+++ b/lua/autorun/server/sv_increase_starting_ammo.lua
@@ -1,4 +1,4 @@
-BlacklistedAmmo = { 
+local blacklistedAmmo = {
     ["Smoke Grenades"] = true,
     ["Flash Grenades"] = true,
     ["Frag Grenades"] = true,
@@ -7,11 +7,11 @@ BlacklistedAmmo = {
 }
 
 function givePlayerCWAmmo(Ply)
-    for AmmoName, bulletInfo in pairs(CustomizableWeaponry.ammoTypes) do
-        if not BlacklistedAmmo[AmmoName] then
-            Ply:SetAmmo(1000,AmmoName)
+    for ammoName, bulletInfo in pairs( CustomizableWeaponry.ammoTypes ) do
+        if not blacklistedAmmo[ammoName] then
+            Ply:SetAmmo( 1000, ammoName )
         end
     end
 end
 
-hook.Add("PlayerSpawn", "CFC-Give-CW2-Ammo", givePlayerCWAmmo)
+hook.Add( "PlayerSpawn", "CFC_CWEnhancements_GiveCW2Ammo", givePlayerCWAmmo )

--- a/lua/autorun/server/sv_increase_starting_ammo.lua
+++ b/lua/autorun/server/sv_increase_starting_ammo.lua
@@ -1,22 +1,17 @@
+BlacklistedAmmo = { 
+    ["Smoke Grenades"] = true,
+    ["Flash Grenades"] = true,
+    ["Frag Grenades"] = true,
+    ["40MM"] = true
+    -- we don't actually have to add RPG ammo here
+}
 
-local function givePlayerAmmoForWeapon( player, weapon )
-    local ammoType = weapon:GetPrimaryAmmoType()
-    local currentAmmo = player:GetAmmoCount( ammoType )
-    if ( currentAmmo == 0 ) then
-        player:GiveAmmo( 90, ammoType, false )
+function givePlayerCWAmmo(Ply)
+    for AmmoName, bulletInfo in pairs(CustomizableWeaponry.ammoTypes) do
+        if not BlacklistedAmmo[AmmoName] then
+            Ply:SetAmmo(1000,AmmoName)
+        end
     end
 end
 
-local function giveCW2AmmoOnSpawn( player )
-    timer.Simple( 0, function()
-        for _, weapon in pairs( player:GetWeapons() ) do
-            local isCW2Weapon = string.sub( weapon:GetClass(), 1, 2 ) == "cw"
-            if ( isCW2Weapon ) then
-                givePlayerAmmoForWeapon( player, weapon )
-            end
-        end
-    end )
-end
-
-hook.Remove( "PlayerSpawn", "CFC-Give-CW2-Ammo" )
-hook.Add( "PlayerSpawn", "CFC-Give-CW2-Ammo", giveCW2AmmoOnSpawn )
+hook.Add("PlayerSpawn", "CFC-Give-CW2-Ammo", givePlayerCWAmmo)

--- a/lua/autorun/server/sv_increase_starting_ammo.lua
+++ b/lua/autorun/server/sv_increase_starting_ammo.lua
@@ -6,10 +6,10 @@ local blacklistedAmmo = {
     -- we don't actually have to add RPG ammo here
 }
 
-function givePlayerCWAmmo(Ply)
+function givePlayerCWAmmo( ply )
     for ammoName, bulletInfo in pairs( CustomizableWeaponry.ammoTypes ) do
         if not blacklistedAmmo[ammoName] then
-            Ply:SetAmmo( 1000, ammoName )
+            ply:SetAmmo( 1000, ammoName )
         end
     end
 end


### PR DESCRIPTION
Use the CustomizableWeaponry.ammoTypes table to give each ammo type to players when they spawn. Builders are also given 1000 cw ammo but it has no actual effect
tested, works on server